### PR TITLE
Fixes library function colors, PHP tag colors and PHP variable colors, Makefile targets

### DIFF
--- a/Visual Studio Dark.tmTheme
+++ b/Visual Studio Dark.tmTheme
@@ -617,6 +617,17 @@
 				<string>#87CEFA</string>
 			</dict>
 		</dict>
+		<dict>
+			<key>name</key>
+			<string>Makefile: Targets</string>
+			<key>scope</key>
+			<string>entity.name.function.makefile</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4EC9B0</string>
+			</dict>
+		</dict>
 	</array>
 	<key>uuid</key>
 	<string>2fd1a8f9-ddfd-11e2-a28f-0800200c9a66</string>

--- a/Visual Studio Dark.tmTheme
+++ b/Visual Studio Dark.tmTheme
@@ -211,7 +211,7 @@
 			<key>name</key>
 			<string>Function name</string>
 			<key>scope</key>
-			<string>entity.name.function, keyword.other.name-of-parameter.objc</string>
+			<string>entity.name.function, keyword.other.name-of-parameter.objc, support.function.any-method</string>
 			<key>settings</key>
 			<dict>
 				<key>fontStyle</key>

--- a/Visual Studio Dark.tmTheme
+++ b/Visual Studio Dark.tmTheme
@@ -317,7 +317,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#FFFFFF</string>
+				<string>#a559ac</string>
 			</dict>
 		</dict>
 		<dict>
@@ -394,13 +394,24 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>Embedded source</string>
+			<string>PHP Tags</string>
 			<key>scope</key>
-			<string>text source, string.unquoted</string>
+			<string>punctuation.section.embedded.begin.php, punctuation.section.embedded.end.php</string>
 			<key>settings</key>
 			<dict>
-				<key>background</key>
-				<string>#282828</string>
+				<key>foreground</key>
+				<string>#808080</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>PHP Variable</string>
+			<key>scope</key>
+			<string>punctuation.definition.variable.php</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#687687</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
I really like your theme, but I think some things were missing, so here's a PR with some suggestions: 

- For starters, I missed the highlighted library functions. In Visual Studio some library functions are highlighted in purple, so I added this
- The different background color of an embedded source (e.g. PHP inside HTML) annoyed me as it was really distracting for me (removed it)
- I added colors to the PHP tags in general, so they better fit in with other tags
- When working on a bigger web project you'll notice that the $ in JS is marked as an operator (keyword.operator.js), but PHP variables aren't. I liked the look of it, so I added this for PHP variables too. 
- Makefile targets were not highlighted (I set them to be the same color as class definitions)